### PR TITLE
temporary bug fixes in get_vector

### DIFF
--- a/src/TrafficAssignment.jl
+++ b/src/TrafficAssignment.jl
@@ -10,7 +10,8 @@ include("frank_wolfe.jl")
 
 export
         load_ta_network,
-        ta_frank_wolfe
+        ta_frank_wolfe,
+        TA_Data
 
 
 

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -34,12 +34,16 @@ function get_vector(state, origin, destination, link_dic)
     parent = -1
     x = zeros(Int, maximum(link_dic))
 
-    while parent != origin && origin != destination
+    while parent != origin && origin != destination && current != 0
         parent = state.parents[current]
 
-        link_idx = link_dic[parent,current]
-        if link_idx != 0
-            x[link_idx] = 1
+        # println("origin=$origin, destination=$destination, parent=$parent, current=$current")
+
+        if parent != 0
+            link_idx = link_dic[parent,current]
+            if link_idx != 0
+                x[link_idx] = 1
+            end
         end
 
         current = parent


### PR DESCRIPTION
It later needs to be updated using od_pairs, instead of travel_demand
in all_or_nothing_single/all_or_nothing_parallel.
