### PR TITLE
use 0.6.0-pre as minimum julia version in REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-pre
 LightGraphs 0.8
 Optim 0.7
 BinDeps


### PR DESCRIPTION
this goes along with https://github.com/JuliaGraphs/LightGraphs.jl/pull/628
LightGraphs 0.8 uses syntax that wouldn't work with early 0.6-dev versions,
so better to stick with the 0.5-compatible version of the package there